### PR TITLE
Add a basic PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+#### Description
+<!-- Please, describe what this PR changes and why changes are needed -->
+
+#### Todo
+
+- Does this change need a public announcement? If yes, please update [the agenda of our monthly meeting](https://docs.google.com/document/d/1hjSS-o_cKs5Db1E1TqRykfQfnAQUFS4gDXMQ2x-CSzE/edit?usp=sharing).


### PR DESCRIPTION
#### Description

The main reason behind adding this template is providing a well-defined process to be sure all relevant changes we'll make to our Playbook will be notified to the rest of the team. This will be made in our new monthly meeting.

This change has already been added to the [mentioned document]([the agenda of our monthly meeting](https://docs.google.com/document/d/1hjSS-o_cKs5Db1E1TqRykfQfnAQUFS4gDXMQ2x-CSzE/edit?usp=sharing)). :trollface: 
