### PR TITLE
Remove ToC from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,12 @@
-# The Nebulab playbook <img src="https://github.com/nebulab/playbook/blob/master/logo.png" alt="Nebulab logo" width="25" height="25">
+# The Nebulab playbook
 
-Nebulab is a web consulting company founded in 2012, working mainly on the design and management of 
-web applications for national and international clients. We are a constantly growing company thanks 
-to a team of professionals who love their work and share our principles.
+Nebulab is a consulting agency founded in 2012. We specialize in the design and development of Web
+applications for clients of all sizes.
 
-This manual aims to provide clarity and set out guidelines to be followed in everyday work. Each 
-section contains a series of decisions and reflections that came to light while we were working 
-solidly on various projects.
+We are a constantly growing company thanks to a team of professionals who love their work and share
+the same set of values.
 
-## About us
+This playbook sets out the guidelines we follow in our day-to-day work and operations and is a great
+resource for both new and existing employees.
 
-- [What we do](https://github.com/nebulab/playbook/blob/master/about-us/what-we-do.md)
-- [Our values](https://github.com/nebulab/playbook/blob/master/about-us/our-values.md)
-
-## How we work
-
-- [Where, when and how](https://github.com/nebulab/playbook/blob/master/how-we-work/where-when-and-how.md)
-- [Tools](https://github.com/nebulab/playbook/blob/master/how-we-work/tools.md)
-- [Tracking time](https://github.com/nebulab/playbook/blob/master/how-we-work/tracking-time.md)
-- [Meetings](https://github.com/nebulab/playbook/blob/master/how-we-work/meetings.md)
-- [Client guide](https://github.com/nebulab/playbook/blob/master/how-we-work/client-guide.md)
-
-## Personal growth
-
-- [Mentoring and 1:1s](https://github.com/nebulab/playbook/blob/master/personal-growth/mentoring-and-1-1.md)
-- [Fridays](https://github.com/nebulab/playbook/blob/master/personal-growth/fridays.md)
-- [Benefits](https://github.com/nebulab/playbook/blob/master/personal-growth/benefits.md)
-- [Learning English](https://github.com/nebulab/playbook/blob/master/personal-growth/learning-english.md)
-- [Conferences](https://github.com/nebulab/playbook/blob/master/personal-growth/conferences.md)
-- [Becoming a mentor](https://github.com/nebulab/playbook/blob/master/personal-growth/becoming-a-mentor.md)
-
-## Processes
-
-- [Hiring](https://github.com/nebulab/playbook/blob/master/processes/hiring.md)
-- [Travel policy](https://github.com/nebulab/playbook/blob/master/processes/travel-policy.md)
-- [Paid time off and overtime](https://github.com/nebulab/playbook/blob/master/processes/paid-time-off-and-overtime.md)
-- [Payroll](https://github.com/nebulab/playbook/blob/master/processes/payroll.md)
-- [Workplace health and safety](https://github.com/nebulab/playbook/blob/master/processes/workplace-health-and-safety.md)
-- [Resignation](https://github.com/nebulab/playbook/blob/master/processes/resignation.md)
-
-## The offices
-
-- [Wi-Fi](https://github.com/nebulab/playbook/blob/master/the-offices/wifi.md)
-- [Music](https://github.com/nebulab/playbook/blob/master/the-offices/music.md)
-
-## Working on Nebulab
-
-- [Blog](https://github.com/nebulab/playbook/blob/master/working-on-nebulab/blog.md)
-- [Company projects](https://github.com/nebulab/playbook/blob/master/working-on-nebulab/company-projects.md)
-- [Playbook](https://github.com/nebulab/playbook/blob/master/working-on-nebulab/playbook.md)
-
-## Development
-
-- [Development environment](https://github.com/nebulab/playbook/blob/master/development/development-environment.md)
-- [Style guide](https://github.com/nebulab/playbook/blob/master/development/style-guide.md)
-- [Using Git and GitHub](https://github.com/nebulab/playbook/blob/master/development/using-git-and-github.md)
-- [Documentation](https://github.com/nebulab/playbook/blob/master/development/documentation.md)
-- [Testing](https://github.com/nebulab/playbook/blob/master/development/testing.md)
-- [Working with Rails](https://github.com/nebulab/playbook/blob/master/development/working-with-rails.md)
-- [Design](https://github.com/nebulab/playbook/blob/master/development/design.md)
-
-## Useful resources
-
-- [Privacy policy](https://github.com/nebulab/playbook/blob/master/useful-resources/privacy-policy.md)
-- [Email signature](https://github.com/nebulab/playbook/blob/master/useful-resources/email-signature.md)
-- [Profile picture](https://github.com/nebulab/playbook/blob/master/useful-resources/profile-picture.md)
-- [Press kit](https://drive.google.com/drive/folders/1VATPcbAhnhHZ376_GPixyYAo6u3gN8Os)
+The playbook is live at https://playbook.nebulab.it.

--- a/index.html.md
+++ b/index.html.md
@@ -2,6 +2,13 @@
 title: The Nebulab playbook
 ---
 
-#The Nebulab Playbook
+# The Nebulab Playbook
 
-This manual aims provide clarity and set out guidelines to be followed in everyday work. Each section contains a series of decisions and reflections that came to light while we were working solidly on various projects.
+Nebulab is a consulting agency founded in 2012. We specialize in the design and development of
+Web applications for clients of all sizes.
+
+We are a constantly growing company thanks to a team of professionals who love their work and
+share the same set of values.
+
+This playbook sets out the guidelines we follow in our day-to-day work and operations and is a
+great resource for both new and existing employees.


### PR DESCRIPTION
Now that the website is live, we can remove the table of contents from the readme and simply link people to the live site.