### PR TITLE
Add Press Kit as a topic

### DIFF
--- a/useful-resources/press-kit.html.md
+++ b/useful-resources/press-kit.html.md
@@ -1,0 +1,14 @@
+---
+title: Press kit
+---
+You can find useful brand resources in Nebulab's [Press kit](https://drive.google.com/open?id=1VATPcbAhnhHZ376_GPixyYAo6u3gN8Os), such as:
+
+- [Logo](https://drive.google.com/open?id=1f5ePg4a00aOrKAXd_AyD05X8MBuJXJiC) 
+- [Fonts](https://drive.google.com/open?id=1sR9XUpUeHY4NfY8Bf1yrfYPN_kvyyOOB)
+- [Video](https://drive.google.com/open?id=187hFrHB0iy8bTZiQ9Pnpt6hb6HKQaMPi)
+
+There are funny resources as well:
+
+- [Ruby Monster's wallpaper](https://drive.google.com/open?id=1lGiPg9pCNHQ-k9j29ZJ_olkZlG0UMLdc)
+
+For HEX code colors and to know how to use these resources, check [Nebulab's Brand Guide](https://drive.google.com/open?id=1ia3X-aFuxSVT5hWtYtfdzplF2TfU2Chs).


### PR DESCRIPTION
Ref to #167
_Press Kit_ was previously a direct link to Google Drive folder; but we miss it after the Playbook restyle, because now, all the topics links to their own md file.
So, in this commit I created the missing `Press Kit.md`

