### PR TITLE
Fix on logo and on the default sidebar links color

### DIFF
--- a/middleman/assets/stylesheets/base/_grid.scss
+++ b/middleman/assets/stylesheets/base/_grid.scss
@@ -19,6 +19,7 @@
   position: relative;
   width: 100%;
   text-align: center;
+  z-index: $header-z-index;
   
   @media (min-width: $device-md) {
     border-right: 1px solid $border-color;

--- a/middleman/assets/stylesheets/base/_variables.scss
+++ b/middleman/assets/stylesheets/base/_variables.scss
@@ -55,3 +55,4 @@ $border-radius-lg: 1.5rem;
 $cookies-z-index:     1001;
 $navbar-z-index:      1000;
 $nav-z-index:         999;
+$header-z-index:      100;

--- a/middleman/assets/stylesheets/components/_navigation.scss
+++ b/middleman/assets/stylesheets/components/_navigation.scss
@@ -113,8 +113,6 @@
 .nav-list > li > a,
 .nav-list > li > a[aria-current]:not([aria-current="false"]),
 .nav-list > li.opened > a {
-  color: $black;
-  
   &::after {
     content: '';
     background-size: 10px auto;
@@ -124,6 +122,11 @@
     right: 0;
     top: 25%;
   }
+}
+
+.nav-list > li > a[aria-current]:not([aria-current="false"]),
+.nav-list > li.opened > a {
+  color: $black;
 }
 
 // Display chevron on hover on large devices


### PR DESCRIPTION
Ref. to #177 and #178 

Now the logo is clickable overall and the default color of the sidebar items is the gray `#898989` that become black `#222` on hover or when the item is `opened`
