### PR TITLE
Adjust the width of paragraphs container on home

### DIFF
--- a/middleman/assets/stylesheets/base/_grid.scss
+++ b/middleman/assets/stylesheets/base/_grid.scss
@@ -102,9 +102,14 @@ section.playbook {
     right: 0;
     min-height: 680px;
   }
-
+  
   @media (min-width: $device-xl) {
     background-size: 680px auto;
+  }
+
+  @media (min-width: $device-xxl) {
+    background-size: 780px auto;
+    min-height: 780px;
   }
 }
 

--- a/middleman/assets/stylesheets/base/_grid.scss
+++ b/middleman/assets/stylesheets/base/_grid.scss
@@ -140,7 +140,7 @@ section.playbook {
     
     @media (min-width: $device-xl) {
       > div:first-of-type {
-        max-width: 40%;
+        max-width: 55%;
       }
     }
   }

--- a/middleman/assets/stylesheets/base/_variables.scss
+++ b/middleman/assets/stylesheets/base/_variables.scss
@@ -37,10 +37,11 @@ $buttons-fs: $extra-small-fs;
 //Grid
 $gutter: 1.5rem;
 //
-$device-sm: 576px;
-$device-md: 768px;
-$device-lg: 992px;
-$device-xl: 1200px;
+$device-sm:  576px;
+$device-md:  768px;
+$device-lg:  992px;
+$device-xl:  1200px;
+$device-xxl: 1900px;
 
 //Nav
 $nav-width: 234px;

--- a/middleman/layouts/shared/_header.html.erb
+++ b/middleman/layouts/shared/_header.html.erb
@@ -5,10 +5,4 @@
       <span class="title">Playbook</span>
     <% end %>
   </div>
-  
-  <div class="nav-button">
-    <span class="nav-button__line"></span>
-    <span class="nav-button__line"></span>
-    <span class="nav-button__line"></span>
-  </div>
 </header>

--- a/middleman/layouts/shared/_sidebar.html.erb
+++ b/middleman/layouts/shared/_sidebar.html.erb
@@ -1,3 +1,8 @@
+<div class="nav-button">
+  <span class="nav-button__line"></span>
+  <span class="nav-button__line"></span>
+  <span class="nav-button__line"></span>
+</div>
 <div class="sidebar">
   <%= partial 'middleman/layouts/shared/navigation' %>
 </div>


### PR DESCRIPTION
The width of the paragraphs container (home page) has been enlarged: from `40%` to `55%`
I also move the menu toggle button outside the `header`: this caused unexpected behavior when the menu was visible on mobile.