### PR TITLE
Update trunk based development link

### DIFF
--- a/development/job_offers.yml
+++ b/development/job_offers.yml
@@ -7,7 +7,7 @@ design and implementation decisions with the team.
 
 Before you start contributing to a project, there are a few things you should know:
 
-- we always use [Trunk Based Development](https://guides.github.com/introduction/flow/):
+- we always use [Trunk Based Development](https://trunkbaseddevelopment.com):
   we use short-lived feature branches for all changes and merge into `master`,
   which serves as the single source of truth for the project's state;
 - we use commit messages that allow us to understand the development history (more info on good


### PR DESCRIPTION
This updates the link to trunk based development.

The old link was referring to the GitHub Flow which is similar... but different from what we do.
