### PR TITLE
Fix a commit message link in using git page

### DIFF
--- a/development/using-git-and-github.html.md
+++ b/development/using-git-and-github.html.md
@@ -19,7 +19,7 @@ If you want to learn more about this, here is a list of interesting links about 
 
 - [https://mislav.net/2014/02/hidden-documentation/](https://mislav.net/2014/02/hidden-documentation/)
 - [http://who-t.blogspot.com/2009/12/on-commit-messages.html](http://who-t.blogspot.com/2009/12/on-commit-messages.html)
-- [https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html](http://who-t.blogspot.com/2009/12/on-commit-messages.html)
+- [https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 
 ## Workflow
 


### PR DESCRIPTION
It is actually linking to the post on the line above.