### PR TITLE
Optimize title tags

### DIFF
--- a/middleman/helpers/title_tag_content_helper.rb
+++ b/middleman/helpers/title_tag_content_helper.rb
@@ -1,0 +1,11 @@
+module TitleTagContentHelper
+  DEFAULT_TITLE_TAG_CONTENT = 'The Nebulab playbook'
+
+  def title_tag_content
+    [@current_chapter_title_tag_content, DEFAULT_TITLE_TAG_CONTENT].compact.join ' | '
+  end
+
+  def current_chapter_title_tag_content=(current_chapter_title_tag_content)
+    @current_chapter_title_tag_content = current_chapter_title_tag_content
+  end
+end

--- a/middleman/layouts/playbook/chapter.erb
+++ b/middleman/layouts/playbook/chapter.erb
@@ -1,5 +1,7 @@
 <!doctype html>
 <html>
+  <% self.current_chapter_title_tag_content = current_chapter.title_tag_content %>
+
   <%= partial "middleman/layouts/shared/head" %>
 
   <body>
@@ -24,7 +26,7 @@
     <%= partial "middleman/layouts/shared/cookies" %>
 
     <%= partial "middleman/layouts/shared/all_js" %>
-    
+
     <%= javascript_include_tag "jquery.nice-select.min.js" %>
     <%= javascript_include_tag "custom-select.js" %>
   </body>

--- a/middleman/layouts/shared/_head.html.erb
+++ b/middleman/layouts/shared/_head.html.erb
@@ -3,10 +3,10 @@
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
 
-  <title><%= current_page.data.title || 'Playbook' %></title>
-  
+  <title><%= title_tag_content %></title>
+
   <%= favicon_tag 'favicon.ico' %>
   <link rel="apple-touch-icon" href="<%= image_path "apple-touch-icon.png" %>" />
-  
+
   <%= stylesheet_link_tag 'playbook-style' %>
 </head>

--- a/middleman/lib/playbook/chapter.rb
+++ b/middleman/lib/playbook/chapter.rb
@@ -39,4 +39,8 @@ class Playbook::Chapter < SimpleDelegator
   def next
     section.chapters[section.chapters.find_index { |chapter| page_id == chapter.page_id }.next]
   end
+
+  def title_tag_content
+    "#{section.data.title} - #{data.title}"
+  end
 end


### PR DESCRIPTION
Fixes #209. From the issue description:

The title tags are too short and not clear about the content of the page. We need to create this kind of structure:

_section name - chapter name | The Nebulab playbook_

e.g., **Personal growth - Becoming a mentor | The Nebulab playbook**

## Todo

- [ ] This change needs a public announcement, _I'll update [the agenda of our monthly meeting](https://tadum.app/rhythms/3JAFLu5H6JKDvLrfzXFZL4nf) once merged_.
- [ ] This change moves content around, _I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/)._
