### PR TITLE
Remove payment for failed technical assessments

### DIFF
--- a/people-ops/hiring.html.md
+++ b/people-ops/hiring.html.md
@@ -109,9 +109,6 @@ tips to help you excel:
 - Pay attention to documentation and Git history.
 - Follow the conventions established on the project.
 - If in doubt, feel free to ask! You have our full support.
- 
-If we don't hire you, we will pay for your work at our standard rate for external consultants, which
-will be shared when the task is assigned to you.
 
 ### Offer
 


### PR DESCRIPTION
We have never actually implemented this practice and no candidate has asked for it. We hope to make it a part of the hiring process once the benefits and structure are clearer.

## Todo

- [ ] This change needs a public announcement, _I'll update [the agenda of our monthly meeting](https://tadum.app/rhythms/3JAFLu5H6JKDvLrfzXFZL4nf) once merged_.
- [ ] This change moves content around, _I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/)._
