### PR TITLE
Fixes a typo on the short name for a day, fixes some url mismatches

### DIFF
--- a/development/style-guide.html.md
+++ b/development/style-guide.html.md
@@ -5,11 +5,11 @@ We follow these guidelines to write clean code and reliable applications:
 
 - Ruby: 
   - [https://github.com/bbatsov/ruby-style-guide](https://github.com/bbatsov/ruby-style-guide)
-  - [https://github.com/uohzxela/clean-code-ruby](https://github.com/bbatsov/ruby-style-guide)
-- Rails: [https://github.com/bbatsov/rails-style-guide](https://github.com/bbatsov/ruby-style-guide)
-- CSS: [https://frontend.18f.gov/css/architecture/](https://github.com/bbatsov/ruby-style-guide)
-- RSpec: [http://betterspecs.org/](https://github.com/bbatsov/ruby-style-guide)
-- Javascript: [https://github.com/airbnb/javascript](https://github.com/bbatsov/ruby-style-guide)
+  - [https://github.com/uohzxela/clean-code-ruby](https://github.com/uohzxela/clean-code-ruby)
+- Rails: [https://github.com/bbatsov/rails-style-guide](https://github.com/bbatsov/rails-style-guide)
+- CSS: [https://frontend.18f.gov/css/architecture/](https://frontend.18f.gov/css/architecture/)
+- RSpec: [http://betterspecs.org/](http://www.betterspecs.org)
+- Javascript: [https://github.com/airbnb/javascript](https://github.com/airbnb/javascript)
 
 **Note:** When reading this section, always keep in mind that, when working on projects, it is 
 important to adapt to the client's style if they have a development team. Otherwise, it is acceptable 

--- a/people-ops/travel-policy.html.md
+++ b/people-ops/travel-policy.html.md
@@ -12,7 +12,7 @@ flight tickets and so on.
 
 ## Travel
 
-Regardless of how much time you spend traveling, we consider travel days (Mon-Fry) as full 8-hour
+Regardless of how much time you spend traveling, we consider travel days (Mon-Fri) as full 8-hour
 workdays. Travel during the weekend (Sat-Sun) is not considered work time, but we always try to book
 trips during the workweek.
 


### PR DESCRIPTION
Unless it's commonly used (but unknown to me), "Fry" is not the correct short name for "Friday".

Url mismatches are self explanatory.

## Todo

- [ ] This change needs a public announcement, _I'll update [the agenda of our monthly meeting](https://tadum.app/rhythms/3JAFLu5H6JKDvLrfzXFZL4nf) once merged_.
- [ ] This change moves content around, _I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/)._
