### PR TITLE
Add basic code to make algolia docsearch work

### DIFF
--- a/middleman/Gemfile.lock
+++ b/middleman/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-18
 
 DEPENDENCIES
   middleman (~> 4.2)

--- a/middleman/assets/images/search.svg
+++ b/middleman/assets/images/search.svg
@@ -1,0 +1,1 @@
+<svg id="a8c3c00d-c512-4910-980a-f70f1b1b4cef" data-name="Livello 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18"><title>Tavola disegno 1</title><path d="M17.82,16.89,12,11a6.76,6.76,0,1,0-.86.86L17,17.76a.62.62,0,0,0,.87-.87ZM6.76,12.23A5.53,5.53,0,1,1,12.29,6.7,5.54,5.54,0,0,1,6.76,12.23Z" fill="#3e3e3e"/></svg>

--- a/middleman/assets/stylesheets/base/_grid.scss
+++ b/middleman/assets/stylesheets/base/_grid.scss
@@ -33,7 +33,7 @@
 
 .main-container {
   position: relative;
-  margin-top: $gutter * 2;
+  margin-top: $gutter;
 }
 
 .footer {

--- a/middleman/assets/stylesheets/components/_algolia-search.scss
+++ b/middleman/assets/stylesheets/components/_algolia-search.scss
@@ -1,0 +1,81 @@
+.playbook-search {
+  padding: 0 $gutter;
+  margin-bottom: $gutter * 2;
+  width: 100%;
+  z-index: $cookies-z-index;
+
+  @media (min-width: $device-md) {
+    top: $header-height;
+    left: 0;
+    padding: $gutter;
+    margin: 0;
+    position: fixed;
+    width: auto;
+    border-right: 1px solid $border-color;
+    width: $nav-width;
+  }
+
+  a {
+    text-decoration: none;
+  }
+
+  .algolia-autocomplete {
+    width: 100%;
+
+    @media (min-width: $device-md) {
+      width: auto;
+    }
+  
+    &::before {
+      position: absolute;
+      top: 12px;
+      left: 13px;
+      content: '';
+      width: 14px;
+      height: 14px;
+      z-index: 1;
+      background: url("../images/search.svg") no-repeat;
+    }
+  
+    input[type=search]{
+      width: 100%;
+      padding: 10px 15px 10px 37px;
+      font-size: $smaller-fs;
+      border: 1px solid darken($border-color, 5%);
+      border-radius: 3px;
+      box-shadow: 0px 3px 6px 0px rgba(0, 0, 0, 0.05);
+      outline: 0;
+      font-family: inherit;
+  
+      &::placeholder {
+        color: lighten($light-grey, 14%);
+      }
+  
+      &:focus {
+        border-color: $primary-color;
+      }
+    }
+
+    .algolia-docsearch-suggestion {
+      &--subcategory-column {
+        font-size: $smaller-fs;
+        color: $light-grey;
+      }
+
+      &--category-header {
+        font-weight: 800;
+        font-size: 1.125em; 
+        border-bottom: 1px solid $border-color;
+      }
+
+      &--highlight {
+        color: $primary-color;
+      }
+
+      &--title {
+        font-size: $menu-fs;
+        font-weight: 800;
+      }
+    }
+  }
+}

--- a/middleman/assets/stylesheets/components/_algolia-search.scss
+++ b/middleman/assets/stylesheets/components/_algolia-search.scss
@@ -20,12 +20,12 @@
   }
 
   .algolia-autocomplete {
-    width: 100%;
+    min-width: 100%;
 
     @media (min-width: $device-md) {
       width: auto;
     }
-  
+
     &::before {
       position: absolute;
       top: 12px;
@@ -36,7 +36,7 @@
       z-index: 1;
       background: url("../images/search.svg") no-repeat;
     }
-  
+
     input[type=search]{
       width: 100%;
       padding: 10px 15px 10px 37px;
@@ -46,35 +46,56 @@
       box-shadow: 0px 3px 6px 0px rgba(0, 0, 0, 0.05);
       outline: 0;
       font-family: inherit;
-  
+
       &::placeholder {
         color: lighten($light-grey, 14%);
       }
-  
+
       &:focus {
         border-color: $primary-color;
       }
     }
 
+    .ds-dropdown-menu {
+      width: 100% !important;
+      min-width: auto;
+      max-width: unset;
+
+      @media (min-width: $device-md) {
+        width: auto;
+        min-width: 500px;
+        max-width: 600px
+      }
+    }
+
     .algolia-docsearch-suggestion {
-      &--subcategory-column {
-        font-size: $smaller-fs;
-        color: $light-grey;
-      }
+      .algolia-docsearch-suggestion {
+        &--subcategory-column {
+          font-size: $smaller-fs;
+          color: $light-grey;
+        }
 
-      &--category-header {
-        font-weight: 800;
-        font-size: 1.125em; 
-        border-bottom: 1px solid $border-color;
-      }
+        &--subcategory-column {
+          display: none;
+          @media (min-width: $device-md) {
+            display: inline-block
+          }
+        }
 
-      &--highlight {
-        color: $primary-color;
-      }
+        &--category-header {
+          font-weight: 800;
+          font-size: 1.125em;
+          border-bottom: 1px solid $border-color;
+        }
 
-      &--title {
-        font-size: $menu-fs;
-        font-weight: 800;
+        &--highlight {
+          color: $primary-color;
+        }
+
+        &--title {
+          font-size: $menu-fs;
+          font-weight: 800;
+        }
       }
     }
   }

--- a/middleman/assets/stylesheets/components/_navigation.scss
+++ b/middleman/assets/stylesheets/components/_navigation.scss
@@ -33,7 +33,7 @@
   @media (min-width: $device-md) {
     display: block !important;
     border-right: 1px solid $border-color;
-    top: $header-height;
+    top: $header-height + 70px;
     width: $nav-width;
   }
 }

--- a/middleman/assets/stylesheets/playbook-style.css.scss
+++ b/middleman/assets/stylesheets/playbook-style.css.scss
@@ -11,6 +11,7 @@
 @import "components/cookies";
 @import "components/custom-select";
 @import "components/heroes";
+@import "components/algolia-search";
 @import "components/navigation";
 @import "components/nav-button";
 

--- a/middleman/layouts/shared/_all_js.html.erb
+++ b/middleman/layouts/shared/_all_js.html.erb
@@ -3,3 +3,13 @@
 <%= javascript_include_tag "dropdown-menu.js" %>
 <%= javascript_include_tag "jquery.cookieBar.min.js" %>
 <%= javascript_include_tag "cookie-policy.js" %>
+
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript">
+  docsearch({
+    apiKey: '1d5a2c0cdca44da84fe6d416f317d05a',
+    indexName: 'nebulab_playbook',
+    inputSelector: '#js-search',
+    debug: false
+  });
+</script>

--- a/middleman/layouts/shared/_head.html.erb
+++ b/middleman/layouts/shared/_head.html.erb
@@ -12,4 +12,5 @@
   <link rel="apple-touch-icon" href="<%= image_path "apple-touch-icon.png" %>" />
 
   <%= stylesheet_link_tag 'playbook-style' %>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 </head>

--- a/middleman/layouts/shared/_navigation.html.erb
+++ b/middleman/layouts/shared/_navigation.html.erb
@@ -1,6 +1,5 @@
 <nav class="nav">
   <div>
-    <input type="search" name="playbook-search" placeholder="Search in the playbook" id="js-search">
     <ul class="nav-list">
       <% Playbook::Section.all(app).sort_by { |section| section.data.position }.each do |section| %>
         <li class="nav-list-item <%= current_section && current_section.page_id == section.page_id ? 'opened' : nil %>">

--- a/middleman/layouts/shared/_navigation.html.erb
+++ b/middleman/layouts/shared/_navigation.html.erb
@@ -1,5 +1,6 @@
 <nav class="nav">
   <div>
+    <input type="search" name="playbook-search" placeholder="Search in the playbook" id="js-search">
     <ul class="nav-list">
       <% Playbook::Section.all(app).sort_by { |section| section.data.position }.each do |section| %>
         <li class="nav-list-item <%= current_section && current_section.page_id == section.page_id ? 'opened' : nil %>">

--- a/middleman/layouts/shared/_sidebar.html.erb
+++ b/middleman/layouts/shared/_sidebar.html.erb
@@ -1,3 +1,7 @@
+<div class="playbook-search">
+  <input type="search" name="playbook-search" placeholder="Search..." id="js-search">
+</div>
+
 <div class="nav-button">
   <span class="nav-button__line"></span>
   <span class="nav-button__line"></span>


### PR DESCRIPTION
This PR adds search to our Playbook, via [Algolia Docsearch](https://community.algolia.com/docsearch/).

**TL;DR**: DocSearch is built in two parts:
– a crawler which we run on their own infrastructure every 24 hours. It follows every link in the Nebulab website and extracts content from every page it traverses. It then pushes this content to an Algolia index.
– a JavaScript snippet to be inserted in our website, which is what this PR does.

## Checklist

- ~[ ] This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/)._~
