### PR TITLE
Add client trip process and tips to Leading teams

### DIFF
--- a/leading-teams.html.md
+++ b/leading-teams.html.md
@@ -7,4 +7,5 @@ position: 5
 playbook-section-chapters:
   - Interacting with mentors
   - Working with clients
+  - Visiting clients
 ---

--- a/leading-teams/visiting-clients.html.md
+++ b/leading-teams/visiting-clients.html.md
@@ -1,0 +1,72 @@
+---
+title: Visiting clients
+---
+
+When we have been with a client for more than a year, we should consider scheduling a trip to visit
+them. This strengthens our relationship with the client and allows us to investigate further
+business opportunities, either with the same client or interesting referrals.
+
+Ideally, the entire team should take part in the trip. If this is not possible, the team lead can go
+by themselves.
+
+## Scheduling the trip
+
+The first step is communicating the trip to the client and determining when the best time to visit
+would be. Communication with the client will be different depending on the client's style, size and
+structure, so it's the team lead's responsibility, but you should follow these tips:
+
+- Make sure this is a good time to visit the client, i.e. they're not swamped with work and can take 
+  the time to see us. We want them to be genuinely happy to see us.
+- Explain why we are visiting them: we want to get to know them and their business better by seeing
+  how they operate on a day-to-day business.
+- Ask them if they have any recommendations as far as workplace goes. Ideally we want to work from
+  their office to maximize face time, but we don't want to be overwhelming so be open to other
+  options.
+- If appropriate, ask them to introduce us to any interesting leads: other businesses we might work
+  with, their investors, meet-ups etc. If possible, set up dinner/coffee with these people.
+- Research any interesting meet-ups/events to attend in the client's city during your stay.
+
+## Collaborating in-person
+
+Visiting clients is a completely different trip when compared to conferences and team retreats. You
+will be working full-time from an office you have never seen. These are some of the things you
+should keep in mind:
+
+- Clients may not do the same office hours. When working there try to match their way of doing
+  things both in terms of entering/leaving the office and number of hours worked.
+- You can skip using harvest if you're going to be focused 100% on the client. Just remember to
+  report 7 hours on Harvest at the end of the day.
+- You will do client work on Friday. If you want, feel free to do an extra-day of self-improvement
+  when you're back at the office.
+- You're not there for vacation. Even if the city is so cool... try to maximize the work
+  face-to-face with the client. This means you cannot take a day off because you want to visit the
+  Colosseum.
+- The client's office might not be as cool/comfortable as the one we have in Italy. If you're not
+  comfortable, try explaining what you're used to to the client and see if they can find a better
+  arrangement. If this is extremely important to you, ask the client for details before going there.
+- People will probably be very different from what you expect. We are generally very warm and
+  welcoming... clients might not be. The cultural distance might be much higher than what you get
+  from Slack and voice calls. A good example is: people in the US don't kiss each other on the
+  cheeks for greeting.
+- Never use Slack. Try to maximize the face-to-face time. Pair, chat, have coffee together. Even if
+  the client's team writes to you on Slack (and they will, because it's what they're used to), try
+  to talk to them in person.
+
+## Cool things to do
+
+Planning ahead for activities and bonding moments is crucial for a successful client trip. Here are
+some ideas to have a good time:
+
+- Schedule a yearly roadmap meeting. Talk about future plans, team size and deadlines. The team
+  should answer questions like: "what's the big picture?", "are we going in the right direction?",
+  "are stakeholders connected with the development team?", "can we improve the current process?",
+  "will we deliver everything on the roadmap on time?", ...
+- Plan for a certain number of hours, everyday, just for pairing. Try do to at least 3 hours of pair
+  time every day. Also, try to pair each day with a different person if you can, the least you know
+  them, the better.
+- If they're interested, schedule a meeting with people that founded the company. Depending on the
+  client it might be somebody you already know or someone you don't even know the name of.
+- Ask in advance how you will be seated at the office (and if they have office space available at
+  all). If the traveling team is big it might be hard to have everybody seated comfortably.
+- Plan a night out or a cool activity together. Have beers, fight bears or go for a run in the park.
+  Doing something out of the office is really important to bond so... have fun!


### PR DESCRIPTION
This has been in our internal private playbook for far too long.

There's no reason it shouldn't be shared with the world, since it's also useful for clients who host us!

## Checklist

- [ ] ~This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/).~
