### PR TITLE
Add anchor links to contents titles

### DIFF
--- a/middleman/assets/javascripts/chapter.js
+++ b/middleman/assets/javascripts/chapter.js
@@ -1,0 +1,18 @@
+(function addAnchorLinksToContentsTitles() {
+  var $chapterContents = $('.chapter-contents')
+
+  if(!$chapterContents.length > 0) return
+
+  $chapterContents.find('h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]').each(function() {
+    var $title = $(this)
+
+    $title.prepend($('<a/>', {
+      'class': 'local-anchor',
+      href: '#' + $title.attr('id'),
+      html: $('<span/>', {
+        'class': 'local-anchor-content',
+        text: '¶'
+      })
+    }))
+  })
+})()

--- a/middleman/assets/stylesheets/components/_local-anchor.scss
+++ b/middleman/assets/stylesheets/components/_local-anchor.scss
@@ -1,0 +1,25 @@
+.local-anchor {
+  float: left;
+  width: 30px;
+  height: 30px;
+  margin-left: -30px;
+  text-decoration: none;
+  display: inline-block;
+  line-height: 1;
+
+  &:hover {
+    color: #5fbffd;
+  }
+
+  .local-anchor-content {
+    visibility: hidden;
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  &:hover {
+    .local-anchor-content {
+      visibility: visible;
+    }
+  }
+}

--- a/middleman/assets/stylesheets/playbook-style.css.scss
+++ b/middleman/assets/stylesheets/playbook-style.css.scss
@@ -14,5 +14,6 @@
 @import "components/algolia-search";
 @import "components/navigation";
 @import "components/nav-button";
+@import "components/local-anchor";
 
 @import "vendor/nice-select";

--- a/middleman/layouts/playbook/chapter.erb
+++ b/middleman/layouts/playbook/chapter.erb
@@ -12,7 +12,9 @@
         <section class="playbook">
           <%= partial 'middleman/layouts/playbook/chapter/header' %>
 
-          <%= yield %>
+          <div class="chapter-contents">
+            <%= yield %>
+          </div>
 
           <%= partial 'middleman/layouts/playbook/chapter/footer' %>
 
@@ -27,5 +29,6 @@
 
     <%= javascript_include_tag "jquery.nice-select.min.js" %>
     <%= javascript_include_tag "custom-select.js" %>
+    <%= javascript_include_tag "chapter.js" %>
   </body>
 </html>


### PR DESCRIPTION
Fixes #208. It adds anchor links to contents titles so to allow users to  share links related to specific contents of the Playbook. Here a screenshot of the result:

![Schermata del 2019-09-13 16-12-27](https://user-images.githubusercontent.com/283320/64869734-3fea0e00-d642-11e9-968c-ee44df6ea992.png)

@mfrecchiami and @davidedistefano please have a look ;) 
