### PR TITLE
Distinguish between Mentors and Team Leads more clearly

### DIFF
--- a/leading-teams.html.md
+++ b/leading-teams.html.md
@@ -5,7 +5,8 @@ image:
   width: 366
 position: 5
 playbook-section-chapters:
-  - Interacting with mentors
+  - What team leads do
   - Working with clients
+  - Interacting with mentors
   - Visiting clients
 ---

--- a/leading-teams/what-team-leads-do.html.md
+++ b/leading-teams/what-team-leads-do.html.md
@@ -1,0 +1,49 @@
+---
+title: What team leads do
+meta_description: >
+  Team leads act as project managers at Nebulab, helping with the definition and prioritization of
+  issues and coordinating their team's work. You can learn more about their role in our Playbook! 
+---
+
+At Nebulab, we don't have official project managers. Because we often provide team augmentation
+services or work on projects that are not complex enough to justify a full-time PM, we decided to
+go with a hybrid role and have Team Leads instead.
+
+Team Leads act as informal project managers on the project they're assigned to, defining and
+prioritizing issues, coordinating the team's work and handling communication with the client.
+However, they are still very much hands-on and write code every day along with the rest of their
+team. We feel like this is the perfect amount of structure for the time being.
+
+Being a team lead is as much a privilege as it is a chore:
+ 
+- Team leads do not get nearly as much time for technical work as individual contributors - 
+  realistically, a team lead can expect to spend half their time writing code and the other half 
+  managing the project and the team.
+- Team leads are rarely able to work on their own Friday projects, because their Fridays are
+  usually occupied by company-level initiatives.
+- All this management work is not as visible as technical contributions, so if you're someone who
+  needs a very tight feedback loop (i.e. you need to immediately see the results of your work), you
+  might find this role to be frustrating.
+- As a team lead, you are accountable for the work done by other people. At times, this can feel
+  like you don't have as much control as you used to, because you won't be able to fix every issue
+  by yourself anymore.
+
+You should keep in mind that being a team lead is not the only way to advance in Nebulab: there is
+always room for people to grow as individual contributors, and you shouldn't feel pressured to get
+into the role just because you think it's the only option.
+
+If you still want to become a team lead, with all the pros and cons that entails, read on!
+
+## Applying as a team lead
+
+The first step to become a team lead is to talk to your mentor. They will help you figure out if
+you are ready and where to start. One thing to keep in mind is that we can only have one team lead
+per project, so there might not be space for new team leads even though you are a good fit. If
+that's the case, just be patient and wait for the next project!
+
+We usually assign team leads to projects where they already have experience as an IC. If that's not
+possible (because the project doesn't warrant or already has a team lead), we'll find a suitable
+project for you where you can take on the new role.
+
+Of course, you will still hold regular 1:1s with your mentor, who will follow your progress and give
+you advice on how to improve your team lead skills.

--- a/mentoring-people/what-mentors-do.html.md
+++ b/mentoring-people/what-mentors-do.html.md
@@ -13,42 +13,12 @@ Nebulab is kind of a big deal!
 A mentor has many different responsibilities towards the company and their mentees, among them:
 
 - Mentors ensure their mentees are always happy and growing, both as people and professionals.
-- Mentors attend strategic meetings and help define company-wide policies and initiatives.
-- Mentors act as informal project managers for clients, helping them to plan the work to do.
-- Mentors lead by example, embodying the Nebulab values and culture.
+- Mentors are the bridge between their mentees and Nebulab, relying information back and forth.
+- Mentors run regular 1:1s with their mentees to provide feedback and answer questions.
+- Mentors evaluate their mentees with the [competency matrix](/personal-growth/competency-matrix/)
+  and propose promotions.
 
-With that said, being a mentor is as much of a privilege as it is a chore, and it also has its
-downsides:
- 
-- Mentors do not get nearly as much time for technical work as individual contributors - 
-  realistically, a mentor can expect to spend half their time writing code and the other half 
-  managing projects and people.
-- Similarly, mentors are rarely able to work on their own Friday projects, because their Fridays are
-  usually eaten by 1:1s and other meetings and company-related initiatives.
-- All this management work is not as visible as technical contributions, so if you're someone who
-  needs a very tight feedback loop (i.e. you need to immediately see the results of your work), you
-  might find mentoring to be frustrating.
-- As a mentor, you are accountable for other people. At times, this can feel like you don't have as
-  much control as you used to, because you won't be able to fix every issue by yourself anymore.
-
-You should keep in mind that being a mentor is not the only way to advance in Nebulab: there is
-always room for people to grow as individual contributors, and you shouldn't feel pressured to get
-into mentoring just because you think it's the only option.
-
-If you still want to become a mentor, with all the pros and cons that entails, read on!
-
-## How mentoring works
-
-The first step to become a mentor is to... talk to your mentor. :) They will help you figure out if
-mentoring is for you, if you are ready and where to start. One thing to keep in mind is that we try
-to have one mentor every 3/4 individual contributors, so there might not be space for new mentors
-even though you are a good fit. If that's the case, just be patient and wait for the next hires!
-
-As a mentor, you will be assigned up to 4 mentees and 3 projects that you will manage. Of course,
-this will happen gradually, so that you have the time to get comfortable with your new role and
-responsibilities. Usually, individual contributors who become mentors are assigned to the client
-and team they are already working with, since it allows them to practice their mentoring skills in
-an environment they already know.
-
-You will still hold regular 1:1s with a member of the leadership team, who will follow your progress
-and give you advice on how to up your mentoring game. Mentors need mentors too, after all!
+Being one of our most crucial responsibilities and one of the activities with the highest impact on
+Nebulab and its team members, mentoring can only be provided by a restricted group of people who
+have proven to be exceptionally capable of leading others. This group currently includes the
+Directors and L5 Team Leads, but we may expand or change the requirements in the future.


### PR DESCRIPTION
Currently, the difference between mentors and team leads is not entirely clear, and some information was outdated (e.g. mentors don't handle client projects anymore).

This is an attempt at providing a good explanation of their different responsibilities.
