### PR TITLE
Use 'Ruby on Rails' instead of 'Rails' for SEO

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -9,3 +9,4 @@
 /people-ops/workplace-health-and-safety /our-offices/workplace-health-and-safety/
 /people-ops/paid-time-off-and-overtime /people-ops/time-off-and-overtime/
 /people-ops/resignation /people-ops/parting-ways/
+/development/working-with-rails /development/working-with-ruby-on-rails/

--- a/development.html.md
+++ b/development.html.md
@@ -10,6 +10,6 @@ playbook-section-chapters:
   - Using Git and GitHub
   - Documentation
   - Testing
-  - Working with Rails
+  - Working with Ruby on Rails
   - Design
 ---

--- a/development/working-with-ruby-on-rails.html.md
+++ b/development/working-with-ruby-on-rails.html.md
@@ -1,5 +1,5 @@
 ---
-title: Working with Rails
+title: Working with Ruby on Rails
 meta_description: >
   When working with Ruby on Rails, having best practices in place can help you move more quickly and
   with more confidence. Here are some of our best tips!


### PR DESCRIPTION
Updates the title of the "Working with Rails" page for better SEO.

Closes #235.

## Checklist

- [x] This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/)._
