### PR TITLE
Require meta description in PR template checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,4 @@
 ## Checklist
 
 - [ ] This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/)._
+- [ ] This change adds a new page and I have asked @ShanaRem to write a meta description.


### PR DESCRIPTION
Requires authors of new pages to get a meta description from @ShanaRem before merging their PR.

## Checklist

- [ ] This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/)._
