### PR TITLE
Fix broken link to Time off and overtime

### DIFF
--- a/how-we-work/tools.html.md
+++ b/how-we-work/tools.html.md
@@ -77,9 +77,9 @@ In order to get an idea of how to track time on Harvest, look at
 In order to keep track of vacations, leave, overtime and sick leave, we use
 [Dipendenti in cloud](https://secure.dipendentincloud.it/app/dashboard).
 
-You can track [time off](people-ops/paid-time-off-and-overtime)
-by clicking to the [Presenze](https://secure.dipendentincloud.it/app/timesheet) tab and clicking on
-a day (or dragging the mouse over several days).
+You can track [time off](/people-ops/time-off-and-overtime) by clicking on the
+[Presenze](https://secure.dipendentincloud.it/app/timesheet) tab and clicking on a day (or dragging
+the mouse over several days).
 
 You can request an expense reimbursement by adding your request in the
 [Spese e Viaggi](https://secure.dipendentincloud.it/app/expenses) tab.


### PR DESCRIPTION
Moz found a broken link in the Tools chapter to the Time off and overtime chapter.