### PR TITLE
Shorten meta descriptions longer than 160 characters

### DIFF
--- a/leading-teams/what-team-leads-do.html.md
+++ b/leading-teams/what-team-leads-do.html.md
@@ -1,8 +1,8 @@
 ---
 title: What team leads do
 meta_description: >
-  Team leads act as project managers at Nebulab, helping with the definition and prioritization of
-  issues and coordinating their team's work. You can learn more about their role in our Playbook! 
+  We don't have official project managers at Nebulab - instead, we have Team Leads! Curious about
+  the difference? Learn more about their role in our Playbook!
 ---
 
 At Nebulab, we don't have official project managers. Because we often provide team augmentation

--- a/people-ops/onboarding.html.md
+++ b/people-ops/onboarding.html.md
@@ -1,8 +1,8 @@
 ---
 title: Onboarding
 meta_description: >
-  Having a well-structured onboarding process is key to making joining your company an amazing
-  experience. Learn about Nebulab's onboarding process in our playbook! 
+  Having a structured onboarding process is key to making joining your company an amazing
+  experience. Learn about Nebulab's onboarding process in our Playbook! 
 ---
 
 Congratulations on joining Nebulab! We're glad to have you aboard, and we can't wait to see what

--- a/personal-growth/competency-matrix.html.md
+++ b/personal-growth/competency-matrix.html.md
@@ -1,8 +1,8 @@
 ---
 title: Competency matrix
 meta_description: >
-  Nebulab has a structured growth framework to ensure our team members always know what the next
-  step is for their career. Read about this process in our Playbook!
+  Nebulab has a growth framework to ensure our team members always know what the next step is for
+  their career. Read about this process in our Playbook!
 ---
 
 In 2018, Nebulab doubled in size, growing from 10 to 20 engineers. This created a unique set of

--- a/working-on-nebulab/management-scrum.html.md
+++ b/working-on-nebulab/management-scrum.html.md
@@ -1,8 +1,8 @@
 ---
 title: Management Scrum
 meta_description: >
-  The Directors run Nebulab as a Scrum product, organizing the work on company policies and
-  initiatives in sprints and iterating constantly. Learn about our approach by reading our Playbook!
+  Did you know that Nebulab, the company, is managed as if it were a Scrum product? If you want to
+  experiment with this approach, find out more in our Playbook!
 ---
 
 Nebulab, the company, is run by a group of 4 directors who handle all aspects of it: strategy, team


### PR DESCRIPTION
Search engines usually truncate descriptions after 160 characters, and we definitely don't want that.

## Checklist

- [ ] This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/)._
- [ ] This change adds a new page and I have asked @ShanaRem to write a meta description.
