### PR TITLE
Add info about expiration of accrued vacation days

### DIFF
--- a/people-ops/time-off-and-overtime.html.md
+++ b/people-ops/time-off-and-overtime.html.md
@@ -21,8 +21,11 @@ the amounts corresponding to the previous year, but which can still be taken.
 ## Vacation
 
 There are 22 days of vacation per year (176 hours). All members of the team must communicate the
-vacations days they wish to take via chat or verbally, with a notice of at least two weeks if
-possible. 
+vacation days they wish to take via chat or verbally, with a notice of at least two weeks if
+possible.
+
+Holidays accrued in a year must be used within 18 months: e.g., the remaining days on 31/12/2019
+must be used by 1/06/2021.
 
 ## Time off, special leave and overtime
 


### PR DESCRIPTION
There was a piece of missing but useful information about how much time Nebulab can keep accrued days that a team member can spend as vacation time.