### PR TITLE
Add Leadership principles to Leading teams

### DIFF
--- a/leading-teams.html.md
+++ b/leading-teams.html.md
@@ -7,6 +7,7 @@ social_cover: leading-teams.png
 position: 5
 playbook-section-chapters:
   - What team leads do
+  - Leadership principles
   - Working with clients
   - Handling conflict
   - Giving feedback

--- a/leading-teams/leadership-principles.html.md
+++ b/leading-teams/leadership-principles.html.md
@@ -1,0 +1,73 @@
+---
+title: Leadership principles
+meta_description: >
+  Managing people is an art more than a science, but we have collected some leadership principles
+  that resonate with us. Learn about them in our Playbook!
+---
+
+Managing people and teams is an art more than a science, but here are some principles we find useful
+to practice in our day-to-day work:
+
+* **Have clear priorities.** Your priorities should be, from most to least important: (1) the
+  project; (2) the team; (3) the people that make the team; (4) you. These is a fine line between
+  making compromising between these four priorities and sacrificing one for the others. Compromising
+  is okay, especially in the short-term — burnout is not.
+* **Stay human.** As a manager, it’s easy to get into a "superhero" mindset: you want to help
+  others so much that you forget to ask for help. If you have too much on your plate or are
+  struggling with something, talk it out with someone — ideally your mentor. We all need a hand
+  from time to time. Superhero managers are a danger, not an asset.
+* **Be glue.** Your most important job is to [act as glue](https://noidea.dog/glue) between the
+  different parts of your team, and make sure everyone has all the information they need to do
+  their job. Sometimes, this is just about communicating. Other times, it’s more complex (e.g.
+  doing a PR review, holding a retrospective or a sprint planning).
+* **Give feedback.** Team leads are in a very privileged position: they are managers, and yet they
+  are very much hands-on. Because of this, you are able to provide 360-degree feedback to your team
+  members about all aspects of their work. Remember to give feedback early and often and practice
+  [radical candor](https://www.amazon.it/Radical-Candor-Revised-Kick-Ass-Humanity-ebook/dp/B07P9LPXPT),
+  even and especially when it’s uncomfortable, and work with the mentors of your team members to
+  enrich the information at their disposal and establish growth paths.
+* **Manage risk.** This is easily one of the most valuable things you can do for Nebulab and the
+  client. Because you have the high-level vision of the project, it’s easier for you than for
+  others to foresee any risks in the client’s technology strategy and/or short-term initiatives.
+  Set aside time to identify, communicate and mitigate risk.
+* **Empathize with clients.** We act as if we were spending our money, not the client’s — it’s in
+  our company values, so make sure to honor it. Always seek to understand the client’s point of view
+  first rather than imposing your own. Keep in mind that our clients usually have a very good
+  understanding of their problem domain(s), they’re just unsure about the solution.
+* **Manage up and down.** You should manage both down (i.e. your team) and up (i.e. your client and
+  the directors). Managing up and down is the only way to be truly effective as a team lead. Forget
+  to manage down, and the team will underperform; forget to manage up, and the relationship between
+  you and your client, or you and your manager, will deteriorate.
+* **Seize opportunities.** You may run into a ton of opportunities to improve and consolidate your
+  relationship with the client (team expansion, new initiatives, additional areas of responsibility
+  where you or other team members can become an asset for the client) — get good at identifying
+  them and seizing them, asking others for help when necessary. Be bold.
+* **Foster ownership.** A manager’s most powerful weapon is fostering a sense of ownership in their
+  team, so that they don’t have to delegate tasks because people naturally want to take care of
+  things. Find ways to promote ownership within your team by creating an environment of
+  [Mastery, Autonomy and Purpose](https://www.amazon.it/Drive-Surprising-Truth-Motivates-English-ebook/dp/B0033TI4BW).
+* **Understand the business**. You cannot truly deliver value to the client unless you know how they
+  make money. Take time to truly understand their business domain and the company’s business model.
+  Research the industry, the competition, the most common causes of success and failure, and
+  anything else that can help you and the team become better at what they do. Don’t be afraid to
+  ask.
+* **Promote Nebulab.** Make the client fall in love with Nebulab — not because it’s good for us, but
+  because it’s good for them. Use any chance you have to mentor them about our values and our
+  processes. Do fun things together. Celebrate the small and the big wins. Get to know the client,
+  their team and their culture, and find ways to integrate it with Nebulab’s culture and vision.
+* **Prioritize reflection.** Even though you’re technical, your role as team lead is highly
+  strategic. How you handle a project can make or break our relationship with that client. Don’t
+  just follow the rules, but deliberately set some time away to reflect on what you’re doing. Is
+  there anything you could be doing that would improve the project?
+
+# Books, articles and talks
+
+* [Being Glue](https://noidea.dog/glue)
+* [Drive: The Surprising Truth About What Motivates Us](https://www.amazon.it/Drive-Surprising-Truth-Motivates-English-ebook/dp/B0033TI4BW)
+* [Radical Candor: Fully Revised & Updated Edition: Be a Kick-Ass Boss Without Losing Your Humanity](https://www.amazon.it/Radical-Candor-Revised-Kick-Ass-Humanity-ebook/dp/B07P9LPXPT)
+* [The Manager's Path: A Guide for Tech Leaders Navigating Growth and Change](https://www.amazon.it/Managers-Path-Leaders-Navigating-English-ebook/dp/B06XP3GJ7F)
+* [Managing Humans: Biting and Humorous Tales of a Software Engineering Manager](https://www.amazon.it/Managing-Humans-Humorous-Software-Engineering/dp/1484221575)
+* [Books, Articles and Videos Recommended by Plato Mentors](https://docs.google.com/spreadsheets/d/1C4G6_1G38MDqrhl-RoFIV4eWPb8irD2nOipMDRrwtoo/edit)
+* [An Engineering Team where Everyone is a Leader](https://blog.pragmaticengineer.com/a-team-where-everyone-is-a-leader/)
+* [High Output Management for (Non-managing) Tech Leads](https://www.g9labs.com/2020/01/04/high-output-management-for-non-managing-tech-leads/)
+* [7 ways of giving feedback that encourage change](https://knowyourteam.com/blog/2019/08/29/7-ways-of-giving-feedback-that-encourage-change/?utm_source=email&utm_medium=kytnewsletter&__s=ktamput8bgc2qtmj5xng)


### PR DESCRIPTION
Adds a Leadership principles chapter to the Leading teams section, with some useful information and tips on leading teams.

## Checklist

- [x] This change adds a new page and I have written an appropriate meta description.
