### PR TITLE
Add Netlify redirects from sections to chapter

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -14,3 +14,16 @@
 /mentoring-people/handling-conflict /leading-teams/handling-conflict/
 /mentoring-people/giving-feedback /leading-teams/giving-feedback/
 /leading-teams/interacting-with-mentors /personal-growth/mentors-and-team-leads/
+
+# Redirects of sections to chapters
+/about-us /about-us/what-we-do/
+/how-we-work /how-we-work/where-when-and-how/
+/personal-growth /personal-growth/mentors-and-team-leads/
+/mentoring-people /mentoring-people/what-mentors-do/
+/leading-teams /leading-teams/what-team-leads-do/
+/people-ops /people-ops/hiring/
+/our-offices /our-offices/wifi/
+/working-on-nebulab /working-on-nebulab/management-scrum/
+/development /development/development-environment/
+/useful-resources /useful-resources/privacy-policy/
+/client-guide /client-guide/onboarding/


### PR DESCRIPTION
To make it easier to share links to the playbook each section should be
redirected to the first chapter.

This adds the Netlify redirects needed for this.

Closes #205 