### PR TITLE
Update two missed channels name to new EN name

### DIFF
--- a/how-we-work/donut.html.md
+++ b/how-we-work/donut.html.md
@@ -19,4 +19,4 @@ from an office, it's still great to get to know the rest of the team — in this
 your co-located colleagues so that Donut only pairs you with people you don't know as well.
 
 If you haven't tried Donut yet and would like to participate in the next round of pairings, feel
-free to join the #caffe channel on Slack!
+free to join the #coffee channel on Slack!

--- a/how-we-work/where-when-and-how.html.md
+++ b/how-we-work/where-when-and-how.html.md
@@ -69,7 +69,7 @@ Here is a list of essential things for working remotely:
 
 ### Communication channels
 
-We use the Slack channel #calendario for all communications regarding working time and place. If you
+We use the Slack channel #time-off for all communications regarding working time and place. If you
 intend to work remotely, communicate this as early as possible.
  
 **Important: DO NOT use private messages or unofficial channels for this type of communication!**


### PR DESCRIPTION
Ref. to #300 

I've found only two missed Italian names of Slack channels 🙂 


