### PR TITLE
Add social media to blog publication process

### DIFF
--- a/working-on-nebulab/blog.html.md
+++ b/working-on-nebulab/blog.html.md
@@ -39,10 +39,17 @@ You don't need approval to write a blog post, just follow these simple steps.
 4. After the article has been reviewed  and adjusted, ping #blog again for the marketing tasks.
 5. Once the cover image and the latest SEO refinements have been implemented, your blog post is
    ready to be merged and scheduled for publication.
+6. After the post has been scheduled for publication, access the
+   [Social Media Editorial Plan Board][social-media-board] and create a new card from the existing
+   `[Blog Post]` template. Write in the card a description of up to 200 characters and move it to
+   the `Waiting for approval` column. Board editors will be notified, will review the content and
+   schedule it for publication on social media.
 
 Remember that you, the author of the article, are responsible for the entire publication process, so 
 don't forget to follow your post's progress until its publication, even in phases that do not 
 concern you directly.
+
+[social-media-board]: https://trello.com/b/ocREIETO/nebulab-social-media-editorial-plan
 
 ## Guidelines for writing
 


### PR DESCRIPTION
Adds a new step to blog post publication process: creating a card on our social media board to allow to review and schedule for publication social media content.

## Checklist

- ~~[ ] This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/).~~
- ~~[ ] This change adds a new page and I have written an appropriate meta description.~~
