### PR TITLE
Add the international compensation policy

### DIFF
--- a/people-ops.html.md
+++ b/people-ops.html.md
@@ -7,6 +7,7 @@ social_cover: people-ops.png
 position: 6
 playbook-section-chapters:
   - Hiring
+  - International compensation
   - Onboarding
   - Benefits
   - Time off and overtime

--- a/people-ops/international-compensation.html.md
+++ b/people-ops/international-compensation.html.md
@@ -9,13 +9,13 @@ meta_description: >
 > which we believed to be a good starting point.
 
 We hire people in different regions and countries. Every market is different, and it can be
-challenging to be competitive and fair towards other team members in making an offer for the same
-role but in a different region. The best way to deal with that is by introducing a Location factor.
+challenging to be competitive and fair in making an offer for the same role but in a different
+region. The best way to deal with that is by introducing a Location factor.
 
 ### Why we pay local salaries
 
-The key argumentations on why we value this policy as a critical success factor, both in hiring
-talented people and being fair and profitable as a company, are:
+The reasons why we value this policy as a critical success factor, both in hiring talented people
+and being fair and profitable as a company, are:
 
 - having a strict salary structure will bring low competitiveness in high salary regions – this
 mainly means that we can't hire people in that area;
@@ -40,26 +40,21 @@ It goes without saying that the latter can be far higher than the first one; in 
 result in paying someone far more than what he's going to obtain from his local market just because
 he lives in an expensive area.
 
-To determine the Location factor, we select the area the candidate lives in first, using a couple of
-convenient rules.  
-
-### International hires
-
-For candidates who live outside of Italy, if they live within a commutable one hour and thirty
-minutes (1:30) of a city listed, we may use that as their location.
-
-### Italian hires
-
-Because of the peculiar characteristic of the territory, for candidates who live in Italy, if they
-live within a commutable twenty minutes (0:20) of an Italian city listed, we may use that as their
-location.
+E.g., taking Atlanta, GA, as the home base (100%), the cost of labor and the cost of living in
+Manhattan, New York are respectively 123% and 217%. This means that the cost of living increase in
+Manhattan is more than proportional than the cost of labor one (ref. [ERI Blog](https://www.erieri.com/blog/post/cost-of-labor-vs-cost-of-living)).
 
 ### Get the indexed salary
 
-Once we get the area the candidate lives in, the math is easy as pie:
+Once we get the candidate's area, we pick the corresponding Location factor within a list of
+worldwide locations.
+
+The calculation basis is the Average Italian Salary matrix for that role. The Location factors are
+modulated on the Italian location factor that represents the unit basis. So we obtain the indexed
+salary by multiplying the matrix and the Location factor of interest.
 
 ```
-(Average Italian salary for that role)/(Italy's Location factor)*(Candidate's Location factor)
+(Average Italian salary)*(Candidate's Location factor)
 ```
 
 We don't feel ready to share our compensation packages publicly yet, although they are readily

--- a/people-ops/international-compensation.html.md
+++ b/people-ops/international-compensation.html.md
@@ -1,0 +1,52 @@
+---
+title: International Compensation
+meta_description: >
+  Nebulab aims to hire the best fit-talents both in culture and skill-set.
+  Our international compensation policy aims to pay the right salary for them.
+  Find out how we handle this!
+---
+
+We hire people in different regions and countries. Every market is different,
+and it can be challenging to be competitive and fair towards other team members
+in making an offer for the same role but in a different region. The best way to
+deal with that is by introducing a Location factor.
+Most of the work here is inspired by or taken verbatim from [Gitlab's approach to international compensation](https://about.gitlab.com/handbook/total-rewards/compensation/#paying-local-rates),
+in particular:
+
+- why it's crucial [paying local rates](https://about.gitlab.com/handbook/total-rewards/compensation/#why-we-pay-local-rates);
+- using [the market-based approach](https://about.gitlab.com/handbook/total-rewards/compensation/#market-based-approach);
+- the [Location factor](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#location-factor)
+definition.
+
+We recommend reading them for any further reference.
+
+## The Location factor
+To determine the Location factor, we select the area the candidate lives in
+first. To do that, we're going to use [Gitlab's approach](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#geographical-areas).
+
+### International hires
+For candidates who live outside of Italy, if they live within a commutable one
+hour and forty-five minutes (1:45) of a city listed, we may use that as their
+location.
+
+### Italian hires
+For candidates who live in Italy, if they live within a commutable twenty
+minutes (0:20) of an Italian city listed, we may use that as their location.
+
+### Get the indexed salary
+Once we get the area the candidate lives in, the math is easy as pie:
+
+```
+(Average Italian salary for that role)/("Italy, Everywhere else" Location factor)*(Candidate's Location factor)
+```
+
+We don't feel ready to share our compensation packages publicly yet, although
+they are readily available for employees to consult.
+
+## Relocation
+What if someone relocates (for the long-term) outside their current area? We use
+the Location Factor for the [Offer step](https://playbook.nebulab.it/people-ops/hiring/#offer)
+only in order to define the candidate's level.
+
+If someone relocates, it is at the company's discretion whether or not to offer
+a new contract in the new location.

--- a/people-ops/international-compensation.html.md
+++ b/people-ops/international-compensation.html.md
@@ -1,5 +1,5 @@
 ---
-title: International Compensation
+title: International compensation
 meta_description: >
   Nebulab strives to hire the best fit-talents both in culture and skill-set. Our international
   compensation policy aims to pay the right salary for them. Find out how we handle this!

--- a/people-ops/international-compensation.html.md
+++ b/people-ops/international-compensation.html.md
@@ -1,7 +1,7 @@
 ---
 title: International Compensation
 meta_description: >
-  Nebulab aims to hire the best fit-talents both in culture and skill-set.
+  Nebulab strives to hire the best fit-talents both in culture and skill-set.
   Our international compensation policy aims to pay the right salary for them.
   Find out how we handle this!
 ---

--- a/people-ops/international-compensation.html.md
+++ b/people-ops/international-compensation.html.md
@@ -49,9 +49,9 @@ Manhattan is more than proportional than the cost of labor one (ref. [ERI Blog](
 Once we get the candidate's area, we pick the corresponding Location factor within a list of
 worldwide locations.
 
-The calculation basis is the Average Italian Salary matrix for that role. The Location factors are
+The calculation basis is the average Italian salary matrix for that role. The Location factors are
 modulated on the Italian location factor that represents the unit basis. So we obtain the indexed
-salary by multiplying the matrix and the Location factor of interest.
+salary by multiplying the average Italian revenue for that role and the Location factor of interest:
 
 ```
 (Average Italian salary)*(Candidate's Location factor)

--- a/people-ops/international-compensation.html.md
+++ b/people-ops/international-compensation.html.md
@@ -5,41 +5,61 @@ meta_description: >
   compensation policy aims to pay the right salary for them. Find out how we handle this!
 ---
 
+> Note: The work here is inspired by [Gitlab's approach to international compensation](https://about.gitlab.com/handbook/total-rewards/compensation/#paying-local-rates),
+> which we believed to be a good starting point.
+
 We hire people in different regions and countries. Every market is different, and it can be
 challenging to be competitive and fair towards other team members in making an offer for the same
 role but in a different region. The best way to deal with that is by introducing a Location factor.
-Most of the work here is inspired by or taken verbatim from
-[Gitlab's approach to international compensation](https://about.gitlab.com/handbook/total-rewards/compensation/#paying-local-rates),
-in particular:
 
-- why it's crucial [paying local rates](https://about.gitlab.com/handbook/total-rewards/compensation/#why-we-pay-local-rates);
-- using [the market-based approach](https://about.gitlab.com/handbook/total-rewards/compensation/#market-based-approach);
-- the [Location factor](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#location-factor)
-  definition.
+### Why we pay local salaries
 
-We recommend reading them for any further reference.
+The key argumentations on why we value this policy as a critical success factor, both in hiring
+talented people and being fair and profitable as a company, are:
+
+- having a strict salary structure will bring low competitiveness in high salary regions – this
+mainly means that we can't hire people in that area;
+- having a strict salary structure will bring high competitiveness in low salary regions – this will
+bring a geographical concentration of team members, instead of a distributed team which represents
+our main goal. Besides, people who are unhappy with their job are less likely to leave if their
+compensation is higher than the average market one;
+- it's fair for anyone having the same wage for the same role, as far as discretional – team members
+are treated equally by the company, which brings a sense of fairness to the team.
 
 ## The Location factor
 
-To determine the Location factor, we select the area the candidate lives in first. To do that, we're
-going to use [Gitlab's approach](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#geographical-areas).
+The Location factor is a multiplier of our former salary matrix.
+
+An important note is that we determine factors by using each country's labor index cost instead of
+the cost of living. The difference between them is thin but still relevant:
+
+- cost of labor is the cost to hire and retain local nationals;
+- cost of living is the cost to maintain a certain standard of living within a geographic location.
+
+It goes without saying that the latter can be far higher than the first one; in some cases, it will
+result in paying someone far more than what he's going to obtain from his local market just because
+he lives in an expensive area.
+
+To determine the Location factor, we select the area the candidate lives in first, using a couple of
+convenient rules.  
 
 ### International hires
 
-For candidates who live outside of Italy, if they live within a commutable one hour and forty-five
-minutes (1:45) of a city listed, we may use that as their location.
+For candidates who live outside of Italy, if they live within a commutable one hour and thirty
+minutes (1:30) of a city listed, we may use that as their location.
 
 ### Italian hires
 
-For candidates who live in Italy, if they live within a commutable twenty minutes (0:20) of an
-Italian city listed, we may use that as their location.
+Because of the peculiar characteristic of the territory, for candidates who live in Italy, if they
+live within a commutable twenty minutes (0:20) of an Italian city listed, we may use that as their
+location.
 
 ### Get the indexed salary
 
 Once we get the area the candidate lives in, the math is easy as pie:
 
 ```
-(Average Italian salary for that role)/("Italy, Everywhere else" Location factor)*(Candidate's Location factor)
+(Average Italian salary for that role)/(Italy's Location factor)*(Candidate's Location factor)
 ```
 
 We don't feel ready to share our compensation packages publicly yet, although they are readily
@@ -48,8 +68,8 @@ available for employees to consult.
 ## Relocation
 
 What if someone relocates (for the long-term) outside their current area? We use the Location Factor
-for the [Offer step](https://playbook.nebulab.it/people-ops/hiring/#offer) only in order to define
-the candidate's level.
+for the [Offer step](https://playbook.nebulab.it/people-ops/hiring/#offer) only to define the
+candidate's level.
 
 If someone relocates, it is at the company's discretion whether or not to offer a new contract in
 the new location.

--- a/people-ops/international-compensation.html.md
+++ b/people-ops/international-compensation.html.md
@@ -21,10 +21,10 @@ and being fair and profitable as a company, are:
 mainly means that we can't hire people in that area;
 - having a strict salary structure will bring high competitiveness in low salary regions – this will
 bring a geographical concentration of team members, instead of a distributed team which represents
-our main goal. Besides, people who are unhappy with their job are less likely to leave if their
-compensation is higher than the average market one;
-- it's fair for anyone having the same wage for the same role, as far as discretional – team members
-are treated equally by the company, which brings a sense of fairness to the team.
+our main goal. Besides, we don’t want unhappy employees keeping their job at Nebulab simply because
+they have a competitive salary;
+- it's fair for anyone having the same relative wage for the same role – team members are treated
+equally by the company, which brings a sense of fairness to the team.
 
 ## The Location factor
 

--- a/people-ops/international-compensation.html.md
+++ b/people-ops/international-compensation.html.md
@@ -1,52 +1,55 @@
 ---
 title: International Compensation
 meta_description: >
-  Nebulab strives to hire the best fit-talents both in culture and skill-set.
-  Our international compensation policy aims to pay the right salary for them.
-  Find out how we handle this!
+  Nebulab strives to hire the best fit-talents both in culture and skill-set. Our international
+  compensation policy aims to pay the right salary for them. Find out how we handle this!
 ---
 
-We hire people in different regions and countries. Every market is different,
-and it can be challenging to be competitive and fair towards other team members
-in making an offer for the same role but in a different region. The best way to
-deal with that is by introducing a Location factor.
-Most of the work here is inspired by or taken verbatim from [Gitlab's approach to international compensation](https://about.gitlab.com/handbook/total-rewards/compensation/#paying-local-rates),
+We hire people in different regions and countries. Every market is different, and it can be
+challenging to be competitive and fair towards other team members in making an offer for the same
+role but in a different region. The best way to deal with that is by introducing a Location factor.
+Most of the work here is inspired by or taken verbatim from
+[Gitlab's approach to international compensation](https://about.gitlab.com/handbook/total-rewards/compensation/#paying-local-rates),
 in particular:
 
 - why it's crucial [paying local rates](https://about.gitlab.com/handbook/total-rewards/compensation/#why-we-pay-local-rates);
 - using [the market-based approach](https://about.gitlab.com/handbook/total-rewards/compensation/#market-based-approach);
 - the [Location factor](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#location-factor)
-definition.
+  definition.
 
 We recommend reading them for any further reference.
 
 ## The Location factor
-To determine the Location factor, we select the area the candidate lives in
-first. To do that, we're going to use [Gitlab's approach](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#geographical-areas).
+
+To determine the Location factor, we select the area the candidate lives in first. To do that, we're
+going to use [Gitlab's approach](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#geographical-areas).
 
 ### International hires
-For candidates who live outside of Italy, if they live within a commutable one
-hour and forty-five minutes (1:45) of a city listed, we may use that as their
-location.
+
+For candidates who live outside of Italy, if they live within a commutable one hour and forty-five
+minutes (1:45) of a city listed, we may use that as their location.
 
 ### Italian hires
-For candidates who live in Italy, if they live within a commutable twenty
-minutes (0:20) of an Italian city listed, we may use that as their location.
+
+For candidates who live in Italy, if they live within a commutable twenty minutes (0:20) of an
+Italian city listed, we may use that as their location.
 
 ### Get the indexed salary
+
 Once we get the area the candidate lives in, the math is easy as pie:
 
 ```
 (Average Italian salary for that role)/("Italy, Everywhere else" Location factor)*(Candidate's Location factor)
 ```
 
-We don't feel ready to share our compensation packages publicly yet, although
-they are readily available for employees to consult.
+We don't feel ready to share our compensation packages publicly yet, although they are readily
+available for employees to consult.
 
 ## Relocation
-What if someone relocates (for the long-term) outside their current area? We use
-the Location Factor for the [Offer step](https://playbook.nebulab.it/people-ops/hiring/#offer)
-only in order to define the candidate's level.
 
-If someone relocates, it is at the company's discretion whether or not to offer
-a new contract in the new location.
+What if someone relocates (for the long-term) outside their current area? We use the Location Factor
+for the [Offer step](https://playbook.nebulab.it/people-ops/hiring/#offer) only in order to define
+the candidate's level.
+
+If someone relocates, it is at the company's discretion whether or not to offer a new contract in
+the new location.


### PR DESCRIPTION
We're hiring people outside of Italy. Introducing an international compensation policy, we should be able to offer the right salary to candidates.

## Checklist

- [ ] This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/).
- [x] This change adds a new page and I have written an appropriate meta description.
