### PR TITLE
Fix typos, grammar and increase clarity while giving Grammarly a test run

### DIFF
--- a/about-us/mission.html.md
+++ b/about-us/mission.html.md
@@ -31,5 +31,5 @@ Source to do the same.
 
 We collaborate with companies that share our mindset and working values such as professionalism, 
 transparency, and a sense of mutual respect and cooperation. Our team of trusted, engaged, and 
-motivated individuals understands our clients' real needs and drives them to success throughout a 
+motivated individuals understand our clients' real needs and drive them to success through a 
 high level of empathy, autonomy, and technical skills.

--- a/about-us/mission.html.md
+++ b/about-us/mission.html.md
@@ -13,7 +13,7 @@ developing, and maintaining high-quality eCommerce websites built with Solidus a
 applications.
 
 We strive to produce high-quality work basing our processes and company life on lean principles and 
-respect for people we work with: our teammates, the Open Source community, and our clients.
+respect for the people we work with: our teammates, the Open Source community, and our clients.
 
 ## Teammates
 

--- a/about-us/values.html.md
+++ b/about-us/values.html.md
@@ -26,7 +26,7 @@ other team members.
 * We communicate with simplicity, clarity, and precision.
 * We make all the information at our disposal available.
 * We respond to questions and concerns in a timely fashion.
-* We keep track of our output in agreed upon tools.
+* We keep track of our output in agreed-upon tools.
 
 ## Enjoy both life and work.
 

--- a/about-us/what-we-do.html.md
+++ b/about-us/what-we-do.html.md
@@ -15,7 +15,7 @@ Rails and Solidus. As part of our eCommerce work, we provide the following servi
 * creative front-end development.
 
 At the moment, we do not work on projects outside of the eCommerce/Solidus space, as we believe
-we can still provide a lot of value to that industry.
+we can still provide significant value to that industry.
 
 In the future, we may work on generic Rails projects and/or the design and development of mobile
-applications, when the time is right and we feel ready.
+applications when the time is right, and we feel ready.

--- a/client-guide/agile-workflows.html.md
+++ b/client-guide/agile-workflows.html.md
@@ -16,7 +16,7 @@ such as Scrum and Kanban, however, have been battle-tested by hundreds of thousa
 teams all over the world - they have been working in the wild for years.
 
 At Nebulab, we believe in adopting a well established practice, trying to follow it to the letter,
-and only tweaking it after experience. The end result of this approach is a workflow that leans on
+and only tweaking it after some experience. The end result of this approach is a workflow that leans on
 the shoulders of giants, but also works for your unique needs and challenges. It will not only save
 you time, but also improve the quality and quantity of your team's output dramatically.
 

--- a/how-we-work/all-hands-meeting.html.md
+++ b/how-we-work/all-hands-meeting.html.md
@@ -6,34 +6,34 @@ meta_description: >
 ---
 
 Every month, we hold an All Hands meeting. We use this session to provide useful
-information to all team members, with the intent of increasing transparency on Nebulab's
-direction, successes, failures and next challenges. The meeting covers several topics:
+information to all team members to increase transparency on Nebulab's
+direction, successes, failures, and next challenges. The meeting covers several topics:
 
-- **Welcome.** we welcome new team members. Often, there is a presentation of new
-  hires in front of the rest of team so everyone knows some information about them.
-  Here we may also talk about people who have left the company, if that happens.
+- **Welcome.** we welcome new team members. Often, there is an introduction of new
+  hires to the team, so everyone knows some information about them.
+  Here we may also talk about people who have left the company if that happens.
 - **Strategy.** This topic covers the high-level decisions that we are doing to make
-  Nebulab grow. We talk about new sales initiatives, our hiring process or how we
+  Nebulab grow. We talk about new sales initiatives, our hiring process, or how we
   are setting things up for personal and professional growth of individuals. We share
   such information with everyone both to be aligned and to receive any feedback about
   the direction in which we're going.
 - **New projects.** We introduce new clients, talking about their business, their team,
-  which team members are assigned to work with them and why we think the client is a good
+  which team members are assigned to work with them, and why we think the client is a good
   fit for us. If we have lost a client instead, we honestly share what didn't work with them.
 - **Rotations.** We describe which team members have switched projects and what need they
   are fulfilling with their rotation.
-- **Policy of the Month.** We are very proud of this playbook, it's our set of policies and
+- **Policy of the Month.** We are very proud of this Playbook, it's our set of policies and
   every employee can refer to these pages when they have some doubts about how to behave.
-  Anyway, it's unrealistic to expect that everyone recall all the playbook's content. This
-  space is dedicated to remind a single policy we have in the playbook so we can jog our
+  Anyway, it's unrealistic to expect that everyone recalls all the Playbook's content. This
+  space reminds us about a single policy we have in the Playbook so we can jog our
   memory about that specific thing. The policy of the month is chosen by the meeting's
   organizers.
 - **Playbook changes.** When policies change in our Playbook, there's no better way to
   talk about them with the rest of the team. This allows us to share why things have
   changed and how these differences will impact company life.
-- **Q&A.** We also hold a questions and answers session at end of the meeting. The goal
+- **Q&A.** We also hold a questions and answers session at the end of the meeting. The goal
   here is to give everyone the chance to ask questions about the company or the topics
   discussed during the meeting.
 
 Make sure to join the channel [#all-hands](https://nebulab.slack.com/archives/CHLDKV560) to receive
-the link to the meeting, the meeting notes, updates, agendas and useful links for each All Hands meeting.
+the link to the meeting, the meeting notes, updates, agendas, and useful links for each All Hands meeting.

--- a/how-we-work/donut.html.md
+++ b/how-we-work/donut.html.md
@@ -7,15 +7,15 @@ meta_description: >
 
 Periodically during the week, [Donut](https://donut.com) will pair people in the #coffee channel. It
 will kick off the conversation with a fun icebreaker and then encourage you to take a remote coffee
-or donut together.
+or Donut together.
 
-This can take any form you want, but usually it's a 10-20 minutes video call where you can talk
-about whatever's on your mind — it doesn't have to be work, and in fact most people use it to catch
-up about their hobbies, families and personal lives, and get to know colleagues with whom they
-usually don't have a lot of interaction. Donut is just like any break, and should not be tracked.
+The Donut can take any form you want, but usually, it's a 10-20 minutes video call where you can talk
+about whatever's on your mind — it doesn't have to be work. In fact, most people use it to catch
+up about their hobbies, families, and personal lives to get to know colleagues with whom they
+usually don't have a lot of interaction. Donut is just like any break and should not be tracked.
 
-If you're a remote worker, Donut is a nice way to socialize with the rest of the team. If you work
-from an office, it's still great to get to know the rest of the team — in this case you can "ban"
+If you're a remote worker, Donut is an excellent way to socialize with the rest of the team. If you work
+from an office, it's still great to get to know the rest of the team — in this case, you can "ban"
 your co-located colleagues so that Donut only pairs you with people you don't know as well.
 
 If you haven't tried Donut yet and would like to participate in the next round of pairings, feel

--- a/how-we-work/meetings.html.md
+++ b/how-we-work/meetings.html.md
@@ -6,18 +6,18 @@ meta_description: >
 ---
 
 Communicating via Slack is our bread and butter, but sometimes a synchronous meeting is needed.
-Throughout the years we have built some best practices that help us make our meetings as effective
+We have built some best practices throughout the years that help us make our meetings as effective
 as possible.
 
 For our meetings, we use [Fellow](http://fellow.app), an app that gives us all the tools we
-need to run effective meetings: it manages the agenda, the notes and any todos that arise from the
+need to run effective meetings: it manages the agenda, the notes, and any todos that arise from the
 meeting. Everyone in the company has an account - if you don't have one already, ping @mettiu to get
 invited! While Fellow is best used for recurring meetings, it also works well for one-offs.
 
 ## Organization of the meeting
 
 - **Don't be afraid to say no.** We are all afraid of missing out on important things. However, if
-  you are invited to a meeting but you think that there is no reason for you to be there, don't be
+  you are invited to a meeting but think that there is no reason for you to be there, don't be
   afraid to ask what contribution you could make or what benefit you could get from it. If nobody
   can answer you, your presence is probably not required.
 
@@ -37,26 +37,26 @@ Moreover, if you are the organizer of the meeting:
   to get organized. When the time comes, just enter the meeting without waiting for someone to nudge
   you.
 - **Come prepared.** Since each meeting must have an agenda and objectives, it should be easy to use
-  the ten minutes of preparation time to think what you want to say. This practice helps you
-  structure your thoughts and saves all participants' time.
+  the ten minutes of preparation time to think about what you want to say. This practice helps you
+  structure your thoughts and saves all participants time.
 
 Additionally, if you are the organizer:
 
 - **Send the agenda.** Review the agenda one more time, make sure every point on it has a title and
   a description that covers what the point is about and how to reach a conclusion, and share the
-  agenda with everyone so they have time to read it.
+  agenda with everyone, so they have time to read it.
 
 ## During the meeting
 
 - **Use a headset.** There is nothing worse than speaking without anyone understanding what you are
   saying. Get a good headset and use it for the meetings. DO NOT use a laptop microphone: even if it
-  seems to work well, in reality it does not.
+  seems to work well, in reality, it does not.
 - **Start your camera (if needed).** If others have their camera on, use yours too. Non-verbal
-  communication is important and seeing the face of the person you are talking to helps build trust.
+  communication is important, and seeing the face of the person you are talking to helps build trust.
 - **Take notes.** Taking notes at a meeting is an excellent way to stay focused and allows those who
   did not participate to know what was said and decided. If you cannot take notes, make sure that
   someone is.
-- **Don't veer off topic.** It might be tempting to propose an unrelated idea right when it comes to
+- **Don't veer off-topic.** It might be tempting to propose an unrelated idea right when it comes to
   you, but be respectful of everyone's time and make sure any unrelated points are added to the
   bottom of the current meeting's agenda or to another meeting's agenda.
 
@@ -70,8 +70,8 @@ Additionally, if you are the organizer:
 
 ### Tracking decisions
 
-As the organizer, it is your responsibility to ensure that people follow-up and execute on any
-decisions taken during the meeting, and your strategy for doing this will be different depending on
+As the organizer, it is your responsibility to ensure that people follow up and execute on any
+decisions that were taken during the meeting, and your strategy for doing this will be different depending on
 what kind of decision you have taken.
 
 At Nebulab, we consider decisions taken during a meeting to be one of three possible types:

--- a/index.html.md
+++ b/index.html.md
@@ -4,8 +4,7 @@ title: The Nebulab Playbook
 
 # The Nebulab Playbook
 
-Nebulab is a consulting agency specialized in the design and development of custom eCommerce 
-applications for clients of all sizes.
+Nebulab is a consulting agency specialized in designing and developing custom eCommerce applications for clients of all sizes.
 
 This playbook is a living document and outlines the practices we follow in our day-to-day work on 
 our company and client projects.

--- a/mentoring-people/what-mentors-do.html.md
+++ b/mentoring-people/what-mentors-do.html.md
@@ -13,7 +13,7 @@ Nebulab is kind of a big deal!
 A mentor has many different responsibilities towards the company and their mentees, among them:
 
 - Mentors ensure their mentees are always happy and growing, both as people and professionals.
-- Mentors are the bridge between their mentees and Nebulab, relying information back and forth.
+- Mentors are the bridge between their mentees and Nebulab, relaying information back and forth.
 - Mentors run regular 1:1s with their mentees to provide feedback and answer questions.
 - Mentors evaluate their mentees with the [competency matrix](/personal-growth/competency-matrix/)
   and propose promotions.


### PR DESCRIPTION
@Azeem838 picked up a typo a few weeks ago and I also thought I'd use this opportunity to test what Grammarly could suggest on a couple of pages while I was making the fix. 

There is a really cool VS Code [extension](https://github.com/znck/grammarly) which is actually an unofficial Grammarly client. This makes writing well-edited markdown so much easier.

Result of the test: Even though it can't be blindly followed, Grammarly could be pretty useful for the Playbook and Solidus documentation if there is ever some time to go through the tedious process of editing 😆.

## Checklist

- [ ] This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/).
- [ ] This change adds a new page and I have written an appropriate meta description.
