### PR TITLE
Invalidate CloudFlare cache on updates

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,20 @@
+name: clear-cache
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for CloudFlare pages to finish the deploy
+        uses: jakejarvis/wait-action@v0.1.0
+        with:
+          time: '6m'
+      - name: Purge CloudFlare Cache
+        uses: jakejarvis/cloudflare-purge-action@v0.3.0
+        env:
+          CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}


### PR DESCRIPTION
The playbook is still served by CloudFlare so everytime something
changes we need to invalidate the nebulab.com cache.

<!-- Please, describe what this PR changes and why. -->

## Checklist

- [ ] This change moves content around and I have configured the appropriate [Netlify redirects](https://www.netlify.com/docs/redirects/).
- [ ] This change adds a new page and I have written an appropriate meta description.
