### PR TITLE
Remove phone number from suggested email signature

### DIFF
--- a/source/useful-resources/email-signature.html.md
+++ b/source/useful-resources/email-signature.html.md
@@ -8,5 +8,4 @@ You could use the following template for the signature in your work emails:
 
     —
     Jane Appleseed
-    +1 123 456 7
     https://nebulab.com


### PR DESCRIPTION
We can't recall the reason why we added that information. Doesn't look important anymore.