### PR TITLE
Add a 404 page

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -11,6 +11,7 @@ set :fonts_dir, 'assets/fonts'
 set :helpers_dir, 'lib/helpers'
 
 page '/', layout: 'home'
+page '/404.html', layout: 'home', directory_index: false
 page /.+\.html$/, layout: 'playbook/chapter'
 
 # Ignored chapter indexes

--- a/lib/playbook/section.rb
+++ b/lib/playbook/section.rb
@@ -3,6 +3,7 @@
 class Playbook::Section < SimpleDelegator
   ROOT_FILES_EXCLUDED_BY_PLAYBOOK_SECTIONS = %w[
     index.html.md
+    404.html.md
   ]
 
   attr_reader :resource

--- a/source/404.html.md
+++ b/source/404.html.md
@@ -1,0 +1,7 @@
+---
+title: Page not found
+---
+
+# Uh, oh!
+
+We couldn't find the page you're looking for.


### PR DESCRIPTION
Adds a 404 page to the playbook, so that Cloudflare Pages serves that instead of the index for invalid URLs.
