### PR TITLE
Remove PTO link to nowhere

### DIFF
--- a/source/people-ops/benefits.html.md
+++ b/source/people-ops/benefits.html.md
@@ -41,8 +41,8 @@ In practice, this benefit takes different forms:
 Everyone at Nebulab should work at a healthy, sustainable pace and take time off to mentally
 disconnect from work and recharge.
 
-All teammates get 22 days of [regular PTO](/work-fundamentals/distributed-work), 11 days for
-national holidays and additional permits for sick leave and special paid leave.
+All teammates get 22 days of regular PTO, 11 days for national holidays and additional permits for
+sick leave and special paid leave.
 
 Finally, we have a [schedule flexibility](/work-fundamentals/time-tracking/) PTO allowance of up to
 104 hours per year, depending on length of service. This allows you to come in a little late, leave


### PR DESCRIPTION
`regular PTO` links to `/work-fundamentals/distributed-work/` which has nothing to do with PTOs.

## Checklist

- [ ] This changes the content index and I've made sure `_redirects` are updated.
